### PR TITLE
Add remote script asset loading functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@
         - [`utils`](#utils)
           - [`hash`](#hash)
           - [`chunkify()`](#chunkify)
+        - [`assets`](#assets)
         - [`random`](#random)
         - [`window`](#window)
       - [Methods](#methods)
@@ -168,6 +169,23 @@ function chunkify(str: string, size: number): string[];
 ```js
 const hashChunks = Meraki.utils.chunkify(Meraki.data.tokenHash, 4);
 ```
+
+##### `assets`
+
+The `Meraki.assets` property provides access to several `p5.js` functions that are used to load assets.  These functions are:
+
+- `Meraki.assets.loadStrings()`
+- `Meraki.assets.loadTable()`
+- `Meraki.assets.loadJSON()`
+- `Meraki.assets.loadXML()`
+
+These functions are used to load assets from the Meraki CDN.  For example, to load a JSON file from the CDN:
+
+```js
+const data = await Meraki.assets.loadJSON('your-project-identifier/data.json');
+```
+
+These helper functions should be used instead of the `p5.js` equivalents.
 
 ##### `random`
 

--- a/README.md
+++ b/README.md
@@ -185,7 +185,18 @@ These functions are used to load assets from the Meraki CDN.  For example, to lo
 const data = await Meraki.assets.loadJSON('your-project-identifier/data.json');
 ```
 
-These helper functions should be used instead of the `p5.js` equivalents.
+These helper functions should be used instead of the `p5.js` equivalents.  
+
+> To add script assets for your script, see the "Script Assets" tab in the Meraki Artist dashboard.  On this tab, you can select the data format you'd like to use,
+> modify the contents of the script asset (JSON, etc.), and receive a URL that you can use to load the asset in your script, such as:
+> `a1c1c433-1ae9-2b9b-a8cd-62c55a12b5d2/data.json`
+> This URL would be used as follows:
+
+```js
+const data = await Meraki.assets.loadJSON('a1c1c433-1ae9-2b9b-a8cd-62c55a12b5d2/data.json');
+```
+
+Note the use of `await` in the example above.  The above functions are asynchronous and must be used with `await` or `then()`.
 
 ##### `random`
 

--- a/package.json
+++ b/package.json
@@ -79,5 +79,8 @@
         "prettier": "^2.7.1",
         "ts-jest": "^29.0.3",
         "typescript": "^4.8"
+    },
+    "dependencies": {
+        "axios": "^1.3.4"
     }
 }

--- a/src/Assets.ts
+++ b/src/Assets.ts
@@ -1,0 +1,133 @@
+import axios from 'axios';
+
+/**
+ * The base URL for all script assets, and must end with a trailing slash.
+ */
+const MERAKI_SCRIPT_ASSETS_URL = 'https://mraki.io/script-assets/';
+
+const ensureSuffix = (path: string, suffix: string) => {
+    if (path.endsWith(suffix)) {
+        return path;
+    }
+
+    return path + suffix;
+};
+
+export class Assets {
+    protected sanitizeUrl(url: string) {
+        const parsed = new URL(url);
+        return parsed.pathname.replaceAll('..', '');
+    }
+
+    public async loadStrings(path: string) {
+        path = MERAKI_SCRIPT_ASSETS_URL + this.sanitizeUrl(ensureSuffix(path, '/data.txt'));
+
+        try {
+            const { data } = await axios.get(path);
+            return data;
+        } catch (e) {
+            //
+        }
+
+        return '';
+    }
+
+    public async loadXML(path: string) {
+        path = MERAKI_SCRIPT_ASSETS_URL + this.sanitizeUrl(ensureSuffix(path, '/data.xml'));
+
+        try {
+            const { data } = await axios.get(path);
+            return data;
+        } catch (e) {
+            //
+        }
+
+        return '';
+    }
+
+    /**
+     * Loads a JSON file from a script asset URL, and returns an Object.
+     * Note that even if the JSON file contains an Array, an Object will be returned with index numbers as keys.
+     * @param path
+     * @returns
+     */
+    public async loadJSON(path: string) {
+        path = MERAKI_SCRIPT_ASSETS_URL + this.sanitizeUrl(ensureSuffix(path, '/data.json'));
+
+        try {
+            // @ts-ignore
+            // eslint-disable-next-line no-undef
+            return loadJSON(path);
+        } catch (e) {
+            //
+        }
+
+        return {};
+    }
+
+    /**
+     * Reads the contents of a script asset URL and creates a p5.Table object with its values.
+     * @param {string} path
+     * @param {string} extension
+     * @param {string} header
+     * @param {any} callback
+     * @param {any} allback
+     */
+    public async loadTable(path: string, extension: string, header: string, callback: any, errorCallback: any) {
+        path = MERAKI_SCRIPT_ASSETS_URL + this.sanitizeUrl(ensureSuffix(path, '/data.csv'));
+
+        try {
+            // @ts-ignore
+            // eslint-disable-next-line no-undef
+            return loadTable(path, extension, header, callback, errorCallback);
+        } catch (e) {
+            //
+        }
+
+        return {};
+    }
+
+    /**
+     * Loads an image from the `path` script asset url and creates a p5.Image from it.
+     * @param {string} path
+     * @param {any} successCallback
+     * @param {any} failureCallback
+     */
+    public async loadImage(path: string, successCallback, failureCallback) {
+        if (!path.startsWith('data:image/png;base64')) {
+            path = MERAKI_SCRIPT_ASSETS_URL + this.sanitizeUrl(path);
+        }
+
+        try {
+            // @ts-ignore
+            // eslint-disable-next-line no-undef
+            return loadImage(path, successCallback, failureCallback);
+        } catch (e) {
+            //
+        }
+
+        return {};
+    }
+
+    /**
+     * Creates a new p5.Shader object from the provided vertex and fragment shader script asset file urls.
+     * @param {string} vertFilename
+     * @param {string} fragFilename
+     * @param {any} callback
+     * @param {any} errorCallback
+     */
+    public async loadShader(vertFilename: string, fragFilename: string, callback, errorCallback) {
+        vertFilename = MERAKI_SCRIPT_ASSETS_URL + this.sanitizeUrl(vertFilename);
+        fragFilename = MERAKI_SCRIPT_ASSETS_URL + this.sanitizeUrl(fragFilename);
+
+        try {
+            // @ts-ignore
+            // eslint-disable-next-line no-undef
+            return loadShader(vertFilename, fragFilename, callback, errorCallback);
+        } catch (e) {
+            //
+        }
+
+        return {};
+    }
+}

--- a/src/Meraki.ts
+++ b/src/Meraki.ts
@@ -6,6 +6,7 @@ import { sha256 } from '@/lib/sha256';
 import { MerakiScript } from '@/MerakiScript';
 import { chunkify } from '@/helpers';
 import { BaseRandom } from '@/BaseRandom';
+import { Assets } from '@/Assets';
 
 export interface Dimensions {
     height: number;
@@ -48,6 +49,10 @@ export class Meraki {
             },
             chunkify,
         };
+    }
+
+    get assets() {
+        return new Assets();
     }
 
     get canvas(): Dimensions {


### PR DESCRIPTION
This PR adds the following:

- `Meraki.assets.loadStrings()`
- `Meraki.assets.loadTable()`
- `Meraki.assets.loadJSON()`
- `Meraki.assets.loadXML()`

These should be used in place of the native `p5.js` functions.